### PR TITLE
fix: Prevent text after the table accidentally getting put in a cell

### DIFF
--- a/open_webui_jira.py
+++ b/open_webui_jira.py
@@ -67,6 +67,8 @@ class EventEmitter:
             formatted_row = [str(cell).replace("|", "\\|") for cell in row]
             table += "|" + "|".join(formatted_row) + "|\n"
 
+        table += "\n"
+
         await self.emit_message(table)
 
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/a7cb18c6-a5cc-4145-b459-f2d6a416c9b8)

After:
![image](https://github.com/user-attachments/assets/f86e4bf5-1496-4648-a9bc-99e2021d5559)
